### PR TITLE
Ignoring HTTP 999 responses from LinkedIn URLs

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -29,6 +29,8 @@ function main(siteURL) {
 					// skip
 				} else if (result.brokenReason === 'HTTP_204' && result.url.resolved.startsWith('https://www.youtube.com/')) {
 					// skip
+				} else if (result.brokenReason === 'HTTP_999' && result.url.resolved.startsWith('https://www.linkedin.com/')) {
+					// skip
 				} else if (result.html.tagName === 'link' && result.html.attrName === 'href' && result.html.attrs.rel === 'canonical' && (new URL(result.url.resolved)).pathname === (new URL(result.base.resolved)).pathname) {
 					// skip
 				} else if (result.url.original === `https://github.com/datawire/ambassador-docs/tree/master${new URL(result.base.resolved).pathname.replace(/\/$/, ".md")}`) {


### PR DESCRIPTION
Adding a check to skip 999 responses from URLs that reference LinkedIn pages. Apparently, LinkedIn pages are infamous for this (it's their approach to avoiding automated bots).