### PR TITLE
Updating download page location

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -99,7 +99,7 @@ function main(siteURL) {
 	if (!siteURL.endsWith('/')) {
 		siteURL += '/';
 	}
-	siteChecker.enqueue(siteURL+'user-guide/downloads');
+	siteChecker.enqueue(siteURL+'reference/edgectl-download');
 };
 
 main(process.argv.slice(2)[0] || 'https://www.getambassador.io/');


### PR DESCRIPTION
Feed the actual downloads page to the BLC rather than the URL that directs to it (which bails on the 301).