### PR TITLE
Remove documentation source page skips

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -36,10 +36,6 @@ function main(siteURL) {
 					// skip
 				} else if (result.html.tagName === 'link' && result.html.attrName === 'href' && result.html.attrs.rel === 'canonical' && (new URL(result.url.resolved)).pathname === (new URL(result.base.resolved)).pathname) {
 					// skip
-				} else if (result.url.original === `https://github.com/datawire/ambassador/tree/master/docs${new URL(result.base.resolved).pathname.replace(/\/$/, ".md")}`) {
-					// skip
-				} else if (result.url.original === `https://github.com/datawire/ambassador/tree/master/docs${new URL(result.base.resolved).pathname.replace(/\/$/, "/index.md")}`) {
-					// skip
 				} else {
 					console.log(`Page ${result.base.resolved} has a broken link: "${result.url.original}" (${result.brokenReason})`);
 				}


### PR DESCRIPTION
Removing the skips for "broken" links to documentation page sources.

The "Edit this page on GitHub" links in the footer of our documentation pages used to be hardcoded to the 'master' branch and so would be "broken" for files that didn't (yet) exist on that branch. Now that we're switching to versioned documentation, the links are based on actual brach where the files are located and, as such, should never be "broken".