### PR TITLE
Removing explicit enqueue for edgectl downloads

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -99,7 +99,6 @@ function main(siteURL) {
 	if (!siteURL.endsWith('/')) {
 		siteURL += '/';
 	}
-	siteChecker.enqueue(siteURL+'reference/edgectl-download');
 };
 
 main(process.argv.slice(2)[0] || 'https://www.getambassador.io/');


### PR DESCRIPTION
Removing the explicit enqueue for the edgectl downloads pages now that it has been redirected to the getting started page (which is referenced by other pages on our site).