### PR TITLE
[WIP] Enqueue installer help pages and clean up variables

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -99,6 +99,32 @@ function main(siteURL) {
 	if (!siteURL.endsWith('/')) {
 		siteURL += '/';
 	}
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-acme-challenge');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-crd-manifests');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-login');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-manifests');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-pod-startup');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/certificate-provision');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/dns-name-body');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/dns-name-post');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/dns-propagation');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/email-request');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/existing-crds');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/get-rest-config');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/get-versions');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/host-resource-creation');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/host-retrieval');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/incompatible-crd-versions');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/install-aes');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/install-crds');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/load-balancer');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/manifest-parsing');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/new-for-config');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/no-cluster');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/no-kubectl');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/wait-crds');
+	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/wait-for-aes');
+
 };
 
 main(process.argv.slice(2)[0] || 'https://www.getambassador.io/');

--- a/blc.js
+++ b/blc.js
@@ -1,24 +1,10 @@
 #!/usr/bin/env node
 
 const blc = require('broken-link-checker');
-const path = require('path');
-
-// list of directories in ambassador.git/docs
-const ambassador_docs_dirs = [
-	'about',
-	'concepts',
-	'doc-images',
-	'docs',
-	'edgestack.me',
-	'kat',
-	'reference',
-	'user-guide',
-	'yaml',
-];
 
 function main(siteURL) {
-
 	const site = new URL(siteURL);
+
 	const handleLink = function(result) {
 		if (result.broken === true) {
 			switch (result.url.original) {
@@ -47,16 +33,12 @@ function main(siteURL) {
 		} else if (result.html.tagName === 'link' && result.html.attrName === 'href' && result.html.attrs.rel === 'canonical') {
 			// skip
 		} else {
-			let src = new URL(result.base.resolved);
 			let dst = new URL(result.url.resolved);
 			if (dst.hostname === 'blog.getambassador.io') {
 				// skip
 			} else if (dst.hostname.endsWith('getambassador.io') || dst.hostname.endsWith(site.hostname)) {
 				// This is an internal link--validate that it's relative.
-				let dstIsAbsolutePath = (result.url.original === result.url.resolved) || (result.url.original + '/' === result.url.resolved) || result.url.original.startsWith('/');
 				let dstIsAbsoluteDomain = (result.url.original === result.url.resolved) || (result.url.original + '/' === result.url.resolved) || result.url.original.startsWith('//');
-				let srcIsAmbassadorDocs = ambassador_docs_dirs.includes(src.pathname.split('/')[1]);
-				let dstIsAmbassadorDocs = ambassador_docs_dirs.includes(dst.pathname.split('/')[1]);
 				if (dstIsAbsoluteDomain) {
 					// links within getambassador.io should not mention the scheme or domain
 					// (this way, they work in netlify previews)
@@ -72,6 +54,7 @@ function main(siteURL) {
 		filterLevel: 3,
 		honorRobotExclusions: false,
 	};
+
 	const handlers = {
 		robots: function(robots) {},
 		html: function(tree, robots, response, pageURL) {
@@ -95,10 +78,13 @@ function main(siteURL) {
 	siteChecker = new blc.SiteChecker(options, handlers);
 
 	siteChecker.enqueue(siteURL);
+
 	// pages that no other page links to... :(
+
 	if (!siteURL.endsWith('/')) {
 		siteURL += '/';
 	}
+
 	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-acme-challenge');
 	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-crd-manifests');
 	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/aes-login');
@@ -124,7 +110,6 @@ function main(siteURL) {
 	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/no-kubectl');
 	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/wait-crds');
 	siteChecker.enqueue(siteURL+'docs/latest/topics/install/help/wait-for-aes');
-
 };
 
 main(process.argv.slice(2)[0] || 'https://www.getambassador.io/');


### PR DESCRIPTION
This pull request does the following:

- explicitly enqueues the installer help files (new as of 1.4) to be checked (since they are currently only referenced by the installer, not by any other pages on the site)
- removes variables (some of which were no longer accurate) that were declared but not being used