### PR TITLE
Skipping Initializer URLs as "ugly" links

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -54,7 +54,7 @@ function main(siteURL) {
 		} else {
 			let src = new URL(result.base.resolved);
 			let dst = new URL(result.url.resolved);
-			if (dst.hostname === 'blog.getambassador.io') {
+			if (dst.hostname.startsWith('blog') || dst.hostname.startsWith('app') || dst.hostname.startsWith('k8sinitializer')) {
 				// skip
 			} else if (dst.hostname.endsWith('getambassador.io') || dst.hostname.endsWith(site.hostname)) {
 				// This is an internal link--validate that it's relative.


### PR DESCRIPTION
Links to the Initializer are currently considered "ugly" (see below) but should be ignored just like links to the blog are.

Page https://www.getambassador.io/dev-tools/ has an ugly link: https://app.getambassador.io/ has a domain (did you mean /?)

Page https://www.getambassador.io/ has an ugly link: https://k8sinitializer.getambassador.io/ has a domain (did you mean /?)

Page https://www.getambassador.io/news/datawire-announces-the-k8s-initializer-for-bootstrapping-networking-ingress-and-observability-in-a-new-kubernetes-cluster/ has an ugly link: https://k8sinitializer.getambassador.io/ has a domain (did you mean /?)
