### PR TITLE
Ignoring 400 responses from Twitter

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -32,6 +32,8 @@ function main(siteURL) {
 					// skip
 				} else if (result.brokenReason === 'HTTP_429') {
 					// skip
+				} else if (result.brokenReason === 'HTTP_400' && result.url.resolved.startsWith('https://twitter.com/')) {
+					// skip
 				} else if (result.brokenReason === 'HTTP_999' && result.url.resolved.startsWith('https://www.linkedin.com/')) {
 					// skip
 				} else if (result.brokenReason === 'HTTP_404' && result.url.resolved === 'https://github.com/datawire/project-template/generate') {


### PR DESCRIPTION
This PR adds an exception for 400 responses for Twitter URLs (which we have started seeing a lot of, for seemingly legitimate links).