### PR TITLE
Updating ignore for verylargejavaservice

### DIFF
--- a/blc.js
+++ b/blc.js
@@ -11,7 +11,6 @@ function main(siteURL) {
 			case "https://blog.getambassador.io/search?q=canary":
 			case "https://app.datadoghq.com/apm/traces":
 			case "https://www.chick-fil-a.com/":
-			case "http://verylargejavaservice:8080":
 				break
 			default:
 				if (/^HTTP_5[0-9][0-9]$/.test(result.brokenReason)) {
@@ -27,7 +26,7 @@ function main(siteURL) {
 				} else if (result.brokenReason === 'HTTP_404' && result.url.resolved === 'https://github.com/datawire/project-template/generate') {
 					// GitHub gives a 404 for 'generate' URLs unless you set the 'Accept:' header, and I don't know how to get broken-link-checker to set it.
 					// skip
-				} else if ((result.brokenReason === 'HTTP_undefined' || result.brokenReason === 'BLC_UNKNOWN') && result.url.resolved.startsWith('https://www.haproxy.org/')) {
+				} else if ((result.brokenReason === 'HTTP_undefined' || result.brokenReason === 'BLC_UNKNOWN') && (result.url.resolved.startsWith('https://www.haproxy.org/') || result.url.resolved.startsWith('http://verylargejavaservice'))) {
 					// skip
 				} else if (result.html.tagName === 'link' && result.html.attrName === 'href' && result.html.attrs.rel === 'canonical' && (new URL(result.url.resolved)).pathname === (new URL(result.base.resolved)).pathname) {
 					// skip


### PR DESCRIPTION
Updating ignores so to address the following:

```
Page http://localhost:8000/docs/1.11/telepresence/quick-start/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/1.11/telepresence/quick-start/qs-go/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/1.11/telepresence/quick-start/qs-java/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/1.11/telepresence/quick-start/qs-python-fastapi/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/1.11/telepresence/quick-start/qs-python/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/latest/telepresence/quick-start/ has a broken link: "http://verylargejavaservice.default:8080" (ERRNO_ENOTFOUND)
Page http://localhost:8000/docs/latest/telepresence/quick-start/qs-go/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/latest/telepresence/quick-start/qs-java/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/latest/telepresence/quick-start/qs-python-fastapi/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/latest/telepresence/quick-start/qs-python/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/pre-release/telepresence/quick-start/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/pre-release/telepresence/quick-start/qs-go/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/pre-release/telepresence/quick-start/qs-java/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/pre-release/telepresence/quick-start/qs-python-fastapi/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
Page http://localhost:8000/docs/pre-release/telepresence/quick-start/qs-python/ has a broken link: "http://verylargejavaservice.default:8080" (HTTP_undefined)
```